### PR TITLE
Append messageToRemember

### DIFF
--- a/GPT.cs
+++ b/GPT.cs
@@ -1635,7 +1635,17 @@ public class CPHInline
             // Read the existing file content and update it with the new user information.
             string jsonContent = File.ReadAllText(filePath);
             var userContexts = JsonConvert.DeserializeObject<Dictionary<string, string>>(jsonContent) ?? new Dictionary<string, string>();
-            userContexts[userName] = messageToRemember;
+
+            // Append the new message to the existing value if the key already exists.
+            if (userContexts.ContainsKey(userName))
+            {
+                userContexts[userName] = userContexts[userName] + "; " + messageToRemember;
+            }
+            else
+            {
+                userContexts[userName] = messageToRemember;
+            }
+            
             // Write the updated dictionary back to the file.
             File.WriteAllText(filePath, JsonConvert.SerializeObject(userContexts, Formatting.Indented));
             LogToFile($"Information about user '{userName}' saved: {messageToRemember}", "INFO");


### PR DESCRIPTION
This PR addresses issue #26 by checking to see if a username key exists in the keyword contexts json file, and if so, appends the new information rather than overwriting it.